### PR TITLE
Extend to support QDate and QDateTime columns

### DIFF
--- a/processfeatures.py
+++ b/processfeatures.py
@@ -54,13 +54,19 @@ class ProcessFeatures():
                 self.order_attr_value = self.attrs[self.order_attr_index]
                 self.group_attr_value = self.attrs[self.group_attr_index]
                 for attr in self.attrs:
-                    try:
-                        self.order_value = datetime.strptime(str(self.order_attr_value), str(self.format_attr))
-                    except:
+                    for conversion_fn in (
+                            (lambda d: datetime.strptime(str(d), str(self.format_attr))),
+                            (lambda d: float(d)),
+                            (lambda d: d.toPyDateTime()),
+                            (lambda d: d.toPyDate()),
+                    ):
                         try:
-                            self.order_value = float(self.order_attr_value)
+                            self.order_value = conversion_fn(self.order_attr_value)
+                            break
                         except:
-                            raise ValueError, 'Order field is not an integer type or date format is invalid'
+                            pass
+                    if not hasattr(self, 'order_value'):
+                        raise ValueError, 'Order field is not an integer type or date format is invalid'
                     if attr == self.group_attr_value:
                         try:
                             self.feat_dict[attr].append((self.order_value, self.coords[0], self.coords[1]))


### PR DESCRIPTION
Loop over a series of conversion functions that includes the conversion from a string to a date, a float conversion, and then toDateTime and toDate based on the QDateTime and QDate objects that represent date fields in a table.

Signed-off-by: Henry Walshaw henry.walshaw@gmail.com
